### PR TITLE
Changed options parameter on PrismaDelete to be optional

### DIFF
--- a/packages/plugins/src/delete.ts
+++ b/packages/plugins/src/delete.ts
@@ -32,7 +32,7 @@ export interface onDeleteArgs {
 export class PrismaDelete {
   constructor(
     private prisma: any = new PrismaClient(),
-    private options: { dmmf?: DMMF.Document },
+    private options?: { dmmf?: DMMF.Document },
   ) {}
 
   get dataModel() {


### PR DESCRIPTION
Today the options parameter of constructor PrismaDelete is required, but on my opinion should be optional, this PR change the parameter to optional to avoid pass empty objects.

Before PR:
![image](https://user-images.githubusercontent.com/20682772/97457573-a5698e80-1918-11eb-87eb-c7b557f687c5.png)
![image](https://user-images.githubusercontent.com/20682772/97458072-1ad55f00-1919-11eb-91dc-17eb85c495d9.png)

After PR:
![image](https://user-images.githubusercontent.com/20682772/97458159-317bb600-1919-11eb-9ac9-07b0c160a904.png)
