### PR TITLE
Fix generating graphql-module self relation typeDefs

### DIFF
--- a/packages/generator/src/graphql-modules/index.ts
+++ b/packages/generator/src/graphql-modules/index.ts
@@ -65,7 +65,8 @@ export class GenerateModules extends Generators {
             fileContent = getField(field, fileContent);
           } else if (
             dataField?.kind !== 'object' ||
-            modules.includes(dataField.type + 'Module')
+            modules.includes(dataField.type + 'Module') ||
+            model.name === dataField.type
           ) {
             fileContent = getField(field, fileContent);
           }


### PR DESCRIPTION
I've found a problem after the last fix, self relation typeDefs don't get generated, this PR fix that