### PR TITLE
# Fix typescript error

### DIFF
--- a/packages/generator/src/nexus-prisma-plugin.ts
+++ b/packages/generator/src/nexus-prisma-plugin.ts
@@ -29,6 +29,10 @@ export class GenerateNexusPrismaPlugin extends Generators {
           }}`,
           '@nexus/schema',
         ),
+        this.isJS ? '' : this.getImport(
+          `{ Prisma }`,
+          '@prisma/client',
+        ),
         '\n',
       ];
 
@@ -77,7 +81,7 @@ export class GenerateNexusPrismaPlugin extends Generators {
                       where: '${model.name}WhereInput',
                     },
                     async resolve(_root, args, ctx) {
-                      return ctx.prisma.${modelName.singular}.count(args)
+                      return ctx.prisma.${modelName.singular}.count(args${this.isJS ? '' : ` as Prisma.FindMany${model.name}Args`})
                     },
                   })`);
                 }
@@ -94,7 +98,7 @@ export class GenerateNexusPrismaPlugin extends Generators {
                       take: 'Int',
                     },
                     async resolve(_root, args, ctx) {
-                      return ctx.prisma.${modelName.singular}.findFirst(args)
+                      return ctx.prisma.${modelName.singular}.findFirst(args${this.isJS ? '' : ` as Prisma.FindMany${model.name}Args`})
                     },
                   })`);
                 }


### PR DESCRIPTION
# Fix typescript error
```
Argument of type '{ cursor?: { id?: string | null | undefined; name?: string | null | undefined; } | null | undefined; orderBy?: ({ createdAt?: "asc" | "desc" | null | undefined; id?: "asc" | "desc" | null | undefined; ... 4 more ...; updatedAt?: "asc" | ... 2 more ... | undefined; } | null)[] | null | undefined; skip?: number | ... ...' is not assignable to parameter of type 'Subset<FindFirstUserArgs, FindFirstUserArgs>'.
  Types of property 'where' are incompatible.
    Type '{ AND?: ...[] | null | undefined; createdAt?: { equals?: any; gt?: any; gte?: any; in?: any[] | null | undefined; lt?: any; lte?: any; not?: { equals?: any; gt?: any; gte?: any; in?: any[] | null | undefined; lt?: any; lte?: any; not?: ... | ... 1 more ... | undefined; notIn?: any[] | ... 1 more ... | undefined; } |...' is not assignable to type 'UserWhereInput | undefined'.
      Type 'null' is not assignable to type 'UserWhereInput | undefined'.ts(2345)
```