### PR TITLE
Fix error

### DIFF
--- a/packages/generator/src/nexus-prisma-plugin.ts
+++ b/packages/generator/src/nexus-prisma-plugin.ts
@@ -78,7 +78,7 @@ export class GenerateNexusPrismaPlugin extends Generators {
                     },
                     async resolve(_root, args, ctx) {
                       return ctx.prisma.${modelName.singular}.count(args${
-                    this.isJS ? '' : 'as any'
+                    this.isJS ? '' : ' as any'
                   })
                     },
                   })`);
@@ -97,7 +97,7 @@ export class GenerateNexusPrismaPlugin extends Generators {
                     },
                     async resolve(_root, args, ctx) {
                       return ctx.prisma.${modelName.singular}.findFirst(args${
-                    this.isJS ? '' : 'as any'
+                    this.isJS ? '' : ' as any'
                   })
                     },
                   })`);


### PR DESCRIPTION
```
◣ Generating your files    SyntaxError: Unexpected token, expected "," (35:63)
      33 |                     },
      34 |                     async resolve(_root, args, ctx) {
    > 35 |                       return ctx.prisma.menu.findFirst(argsas any)
         |                                                               ^
      36 |                     },
      37 |                   })
      38 | t.crud.menus({ filtering: true, ordering: true })
```
(argsas any)  >>>>>> (args as any)