### PR TITLE
proposing some minor fix for object filter rendering logic

### DIFF
--- a/admin/src/PrismaTable/Table/Filters.tsx
+++ b/admin/src/PrismaTable/Table/Filters.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 
 import Select from '../../components/Select';
 import { useFilter } from './useFilter';
@@ -288,26 +288,33 @@ const ObjectFilter: React.FC<FilterComponentsProps> = ({
       ? filterValue.some
       : filterValue
     : {};
-  const props: FilterComponentsProps = {
-    field: getField,
-    filterValue: filter[getField.name],
-    setFilter: (value: any) => {
-      const newValue = { ...filter };
-      if (value) {
-        newValue[getField.name] = value;
-      } else {
-        delete newValue[getField.name];
+  const props: FilterComponentsProps | null = getField
+    ? {
+        field: getField,
+        filterValue: filter[getField.name],
+        setFilter: (value: any) => {
+          const newValue = { ...filter };
+          if (value) {
+            newValue[getField.name] = value;
+          } else {
+            delete newValue[getField.name];
+          }
+          setFilter(Object.keys(newValue).length > 0 ? (field.list ? { some: newValue } : newValue) : undefined);
+        },
       }
-      setFilter(
-        Object.keys(newValue).length > 0
-          ? field.list
-            ? { some: newValue }
-            : newValue
-          : undefined,
-      );
-    },
-  };
-
+    : null;
+  
+  useEffect(() => {
+    setCurrentField({
+      id: model.fields[0].name,
+      name: model.fields[0].title,
+    });
+  }, [field]);
+  
+  if (!getField) {
+    return null;
+  }
+  
   let filterComponent;
   if (getField.kind === 'enum') {
     filterComponent = <EnumFilter {...props} />;


### PR DESCRIPTION
scenario: if the filter is currently an object filter, when the user selects another field that is also an object filter, the code breaks, as the current rendering logic is not picking up the new model's fields. Adding a hook to capture field prop updates in object filter prevents cases like this to happen.