### PR TITLE
Resolving MUI theme import error

### DIFF
--- a/packages/create/examples/full-stack-nextjs/src/pages/_document.tsx
+++ b/packages/create/examples/full-stack-nextjs/src/pages/_document.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheets } from '@material-ui/core/styles';
-import theme from 'layouts/material/theme';
+import { theme } from 'layouts/material/theme';
 
 export default class MyDocument extends Document {
   render() {


### PR DESCRIPTION
When starting up the MUI-templated application with `yarn dev`, I received the following error:

TypeError: Cannot read property 'primary' of undefined
    at MyDocument.render (webpack-internal:///./src/pages/_document.tsx:35:73)

I believe this is due to an attempt to import the theme from `_app.tsx` without destructing the exported `theme` const