### PR TITLE
fix: prisma datamodel

### DIFF
--- a/packages/plugins/src/select.ts
+++ b/packages/plugins/src/select.ts
@@ -75,8 +75,8 @@ export class PrismaSelect {
       });
     } else {
       const { Prisma } = require('@prisma/client');
-      if (Prisma.dmmf && Prisma.dmmf.dataModel) {
-        models.push(...Prisma.dmmf.dataModel.models);
+      if (Prisma.dmmf && Prisma.dmmf.datamodel) {
+        models.push(...Prisma.dmmf.datamodel.models);
       }
     }
     return models;


### PR DESCRIPTION
This should fix #202

When I'm passing my own `Prisma.dmmf` the models get parsed correctly via
https://github.com/haleksandre/prisma-tools/blob/1abadc6f2ddfdcf1e14761993d986b5f57f95353/packages/plugins/src/select.ts#L74 

Otherwise the models are empty since it looks for `dataModel` instead of `datamodel`.