### PR TITLE
Make sure model names are PascalCase too

### DIFF
--- a/packages/schema/src/camelCase.ts
+++ b/packages/schema/src/camelCase.ts
@@ -24,7 +24,7 @@ export class CamelCase extends PrismaReader {
           }
           if (i === 0 && line[1].includes('_')) {
             lines.splice(1, 0, `@@map("${modelName}")`);
-            line[1] = this.convertWord(line[1], true);
+            line[1] = this.convertWord(line[1]);
             lines[0] = line.join(' ');
           } else if (!lines[i].includes('@@') && !lines[i].includes('//')) {
             const line = lines[i].replace(/[\n\r]/g, '').split(' ');
@@ -41,7 +41,7 @@ export class CamelCase extends PrismaReader {
             }
             if (cleanLine[1].includes('_') && kind !== 'enum') {
               const index = line.indexOf(cleanLine[1]);
-              line[index] = this.convertWord(cleanLine[1], true);
+              line[index] = this.convertWord(cleanLine[1]);
             }
             lines[i] = line.join(' ');
           }
@@ -71,13 +71,10 @@ export class CamelCase extends PrismaReader {
     }
   }
 
-  private convertWord(word: string, model = false) {
+  private convertWord(word: string) {
     return word
       .split('_')
-      .map((item, index) =>
-        !model && index === 0
-          ? item
-          : item.charAt(0).toUpperCase() + item.slice(1),
+      .map((item, index) => item.charAt(0).toUpperCase() + item.slice(1),
       )
       .join('');
   }


### PR DESCRIPTION
By default this scripts ignore lowercase model names and but converts `relations`, `snake_case` naming to `PascalCase`. 

This edit ensures that all models are consistently named using `PascalCase`

**Example schema:**
```
model attachment {
  id               Int            @id @default(autoincrement())
  path             String
  attachment_type_id Int 
  attachment_type   attachment_type @relation(name: "attachment_to_attachment_type", fields: [attachment_type_id], references: [id])


  @@map("attachment")
}

model attachment_type {
  id          Int          @id @default(autoincrement())
  title       String?      @unique
  attachments attachment[] @relation(name: "attachment_to_attachment_type")
}
```

**Current conversion:** 
```
model attachment {
  id               Int            @id @default(autoincrement())
  path             String
  attachmentTypeId Int            @map("attachment_type_id")
  attachmentType   AttachmentType @relation(name: "attachmentToattachment_type", fields: [attachmentTypeId], references: [id])


  @@map("attachment")
}

model AttachmentType {
  id          Int          @id @default(autoincrement())
  title       String?      @unique
  attachments attachment[] @relation(name: "attachmentToattachment_type")


  @@map("attachment_type")
}
```

**new/Proposed changes:** 
```
model Attachment {
  id               Int            @id @default(autoincrement())
  path             String
  attachmentTypeId Int            @map("attachment_type_id")
  attachmentType   AttachmentType @relation(name: "attachmentToattachment_type", fields: [attachmentTypeId], references: [id])


  @@map("attachment")
}

model AttachmentType {
  id          Int          @id @default(autoincrement())
  title       String?      @unique
  attachments Attachment[] @relation(name: "attachmentToattachment_type")


  @@map("attachment_type")
}
```