### PR TITLE
Introduce `@Pal.omit` attribute

### DIFF
--- a/packages/generator/src/Generators.ts
+++ b/packages/generator/src/Generators.ts
@@ -219,6 +219,12 @@ export class Generators {
   }
 
   protected shouldOmit(docs?: string) {
+    if (!docs?.includes('@Pal.omit')) {
+      return false;
+    }
+    if (docs?.match(/@Pal.omit(\(\))?\b/)) {
+      return true;
+    }
     const innerExpression = docs?.match(/@Pal.omit\(\[(.*?)\]\)/);
     if (innerExpression) {
       const expressionArguments = innerExpression[1]

--- a/packages/generator/src/Generators.ts
+++ b/packages/generator/src/Generators.ts
@@ -218,6 +218,10 @@ export class Generators {
       .replace(/@onDelete\((.*?)\)/, '');
   }
 
+  protected shouldOmit(docs?: string) {
+    return docs?.includes('@Pal.omit');
+  }
+
   protected createFileIfNotfound(
     path: string,
     fileName: string,

--- a/packages/generator/src/Generators.ts
+++ b/packages/generator/src/Generators.ts
@@ -218,14 +218,14 @@ export class Generators {
       .replace(/@onDelete\((.*?)\)/, '');
   }
 
-  protected shouldOmit(docs?: string, name?: 'input' | 'output') {
+  protected shouldOmit(docs?: string) {
     const innerExpression = docs?.match(/@Pal.omit\(\[(.*?)\]\)/);
-    if (innerExpression && name) {
+    if (innerExpression) {
       const expressionArguments = innerExpression[1]
         .replace(/\s/g, '')
         .split(',')
         .filter(Boolean);
-      return expressionArguments.includes(name);
+      return expressionArguments.includes('output');
     }
     return false;
   }

--- a/packages/generator/src/Generators.ts
+++ b/packages/generator/src/Generators.ts
@@ -218,8 +218,16 @@ export class Generators {
       .replace(/@onDelete\((.*?)\)/, '');
   }
 
-  protected shouldOmit(docs?: string) {
-    return docs?.includes('@Pal.omit');
+  protected shouldOmit(docs?: string, name?: 'input' | 'output') {
+    const innerExpression = docs?.match(/@Pal.omit\(\[(.*?)\]\)/);
+    if (innerExpression && name) {
+      const expressionArguments = innerExpression[1]
+        .replace(/\s/g, '')
+        .split(',')
+        .filter(Boolean);
+      return expressionArguments.includes(name);
+    }
+    return false;
   }
 
   protected createFileIfNotfound(

--- a/packages/generator/src/graphql-modules/index.ts
+++ b/packages/generator/src/graphql-modules/index.ts
@@ -40,7 +40,7 @@ export class GenerateModules extends Generators {
         if (!this.excludeFields(model.name).includes(field.name)) {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
-          if (this.shouldOmit(fieldDocs, 'output')) {
+          if (this.shouldOmit(fieldDocs)) {
             return;
           }
           if (dataField?.kind === 'object' && model.name !== dataField.type) {

--- a/packages/generator/src/graphql-modules/index.ts
+++ b/packages/generator/src/graphql-modules/index.ts
@@ -40,6 +40,9 @@ export class GenerateModules extends Generators {
         if (!this.excludeFields(model.name).includes(field.name)) {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
+          if (this.shouldOmit(fieldDocs)) {
+            return;
+          }
           if (dataField?.kind === 'object' && model.name !== dataField.type) {
             if (!extendsTypes.includes(`extend type ${dataField.type}`)) {
               extendsTypes += `extend type ${dataField.type} {`;

--- a/packages/generator/src/graphql-modules/index.ts
+++ b/packages/generator/src/graphql-modules/index.ts
@@ -40,7 +40,7 @@ export class GenerateModules extends Generators {
         if (!this.excludeFields(model.name).includes(field.name)) {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
-          if (this.shouldOmit(fieldDocs)) {
+          if (this.shouldOmit(fieldDocs, 'output')) {
             return;
           }
           if (dataField?.kind === 'object' && model.name !== dataField.type) {

--- a/packages/generator/src/nexus/index.ts
+++ b/packages/generator/src/nexus/index.ts
@@ -49,7 +49,7 @@ export class GenerateNexus extends Generators {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
           const options = this.getOptions(field, fieldDocs);
-          if (this.shouldOmit(fieldDocs)) {
+          if (this.shouldOmit(fieldDocs, 'output')) {
             return;
           }
           if (

--- a/packages/generator/src/nexus/index.ts
+++ b/packages/generator/src/nexus/index.ts
@@ -49,7 +49,7 @@ export class GenerateNexus extends Generators {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
           const options = this.getOptions(field, fieldDocs);
-          if (this.shouldOmit(fieldDocs, 'output')) {
+          if (this.shouldOmit(fieldDocs)) {
             return;
           }
           if (

--- a/packages/generator/src/nexus/index.ts
+++ b/packages/generator/src/nexus/index.ts
@@ -49,6 +49,9 @@ export class GenerateNexus extends Generators {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
           const options = this.getOptions(field, fieldDocs);
+          if (this.shouldOmit(fieldDocs)) {
+            return;
+          }
           if (
             field.outputType.location === 'scalar' &&
             field.outputType.type !== 'DateTime'

--- a/packages/generator/src/sdl/index.ts
+++ b/packages/generator/src/sdl/index.ts
@@ -44,7 +44,7 @@ export class GenerateSdl extends Generators {
         if (!excludeFields.includes(field.name)) {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
-          if (this.shouldOmit(fieldDocs, 'output')) {
+          if (this.shouldOmit(fieldDocs)) {
             return;
           }
           fileContent += `

--- a/packages/generator/src/sdl/index.ts
+++ b/packages/generator/src/sdl/index.ts
@@ -44,6 +44,9 @@ export class GenerateSdl extends Generators {
         if (!excludeFields.includes(field.name)) {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
+          if (this.shouldOmit(fieldDocs)) {
+            return;
+          }
           fileContent += `
           ${fieldDocs ? `"""${fieldDocs}"""\n` : ''}${field.name}`;
           if (field.args.length > 0) {

--- a/packages/generator/src/sdl/index.ts
+++ b/packages/generator/src/sdl/index.ts
@@ -44,7 +44,7 @@ export class GenerateSdl extends Generators {
         if (!excludeFields.includes(field.name)) {
           const dataField = this.dataField(field.name, dataModel);
           const fieldDocs = this.filterDocs(dataField?.documentation);
-          if (this.shouldOmit(fieldDocs)) {
+          if (this.shouldOmit(fieldDocs, 'output')) {
             return;
           }
           fileContent += `


### PR DESCRIPTION
Resolves: https://github.com/paljs/prisma-tools/issues/234

Put this kind of comment to hide a field from the generated types:
```
model User {
  /// @Pal.omit([input,output])
  password      String?
  /// @Pal.omit
  email             String?
}
```

Documentation: https://github.com/paljs/docs/pull/8