### PR TITLE
fix: changing operator breaks the filter

### DIFF
--- a/admin/src/PrismaTable/Table/useFilter.ts
+++ b/admin/src/PrismaTable/Table/useFilter.ts
@@ -49,7 +49,6 @@ export const useFilter = (
       if (state.typingTimeout) clearTimeout(state.typingTimeout);
 
       const newValue = {
-        ...state.value,
         [name]: search || value === false ? search : undefined,
       };
       setState({


### PR DESCRIPTION
we only need one operator at a time. for example: when we change from "equals" to "contains", the filter object becomes {equals: "blah", contains:"blah"}. we only need one at a time