### PR TITLE
Fix bug cannot convert null or undefined to object

### DIFF
--- a/packages/plugins/src/select.ts
+++ b/packages/plugins/src/select.ts
@@ -238,7 +238,9 @@ export class PrismaSelect {
                 field.type,
                 selectObject.select[key],
               );
-              if (Object.keys(subModelFilter.select).length > 0) {
+              if(subModelFilter === true){
+                filteredObject.select[key] = true;
+              } else if (Object.keys(subModelFilter.select).length > 0) {
                 filteredObject.select[key] = subModelFilter;
               }
             }


### PR DESCRIPTION
If submodelFilter is true but also an object (cause its JSON) then return just true