### PR TITLE
fix(admin): fix table filter column highlight

### DIFF
--- a/admin/src/PrismaTable/Table/index.tsx
+++ b/admin/src/PrismaTable/Table/index.tsx
@@ -357,7 +357,7 @@ export const Table: React.FC<TableProps> = ({
                                         ''
                                       )}
                                     </span>
-                                    {!!filters.find(
+                                    {!!filters.filter(Boolean).find(
                                       (item) => item.id === column.id,
                                     ) ? (
                                       <SearchCircleIcon className="h-5 w-5 text-green-500" />


### PR DESCRIPTION
Now, column highlight will search for completed filters only, before comparing filter id.
Filter ids can only be strings, so `filter(Boolean)` will work.

resolve #267 