### PR TITLE
fix[nexus-generator]: args replace if not capitalized models

### DIFF
--- a/admin/src/PrismaTable/Table/index.tsx
+++ b/admin/src/PrismaTable/Table/index.tsx
@@ -357,7 +357,7 @@ export const Table: React.FC<TableProps> = ({
                                         ''
                                       )}
                                     </span>
-                                    {!!filters.find(
+                                    {!!filters.filter(Boolean).find(
                                       (item) => item.id === column.id,
                                     ) ? (
                                       <SearchCircleIcon className="h-5 w-5 text-green-500" />

--- a/packages/generator/src/nexus/templates/index.ts
+++ b/packages/generator/src/nexus/templates/index.ts
@@ -69,7 +69,7 @@ export async function getCrud(
   );
   const args = await generator.getInputTypes(
     capital(type),
-    (key === 'findCount' ? 'findMany' : key) + modelUpper,
+    (key === 'findCount' ? 'findMany' : key) + model,
     false,
   );
   return crud[key]


### PR DESCRIPTION
resolve #269 

Now args replaces will work even if models are not capitalized.