### PR TITLE
fix(nexus): matches the nexus generated bigint type

### DIFF
--- a/packages/nexus/src/scalars/BigInt.ts
+++ b/packages/nexus/src/scalars/BigInt.ts
@@ -8,5 +8,5 @@ export const BigInt = asNexusMethod(
     description: `The \`BigInt\` scalar type represents non-fractional signed whole numeric values.
 @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt`,
   }),
-  'bigInt',
+  'bigint',
 );


### PR DESCRIPTION
`schema.prisma` file

```ts
model FieldDemo {
  id          String    @id @default(cuid())
  theBigInt   BigInt?   @default(0)
}
```

run `prisma generate && pal g`

generated `type.ts` file

```ts
import { objectType } from 'nexus'

export const FieldDemo = objectType({
  nonNullDefaults: {
    output: true,
    input: false
  },
  name: 'FieldDemo',
  definition(t) {
    t.string('id')
    t.nullable.bigint('theBigInt') //<--this line
  }
})
```

`tsc` console error: `t.nullable.bigint is not a function`
