### PR TITLE
Handle @id & @unique with arguments

### DIFF
--- a/packages/schema/src/json.ts
+++ b/packages/schema/src/json.ts
@@ -37,8 +37,8 @@ export class ConvertSchemaToObject extends PrismaReader {
             const field: Field = {
               name: line[0],
               type,
-              isId: line.includes('@id'),
-              unique: line.includes('@unique'),
+              isId: !!line.find(part => part.startsWith('@id')),
+              unique: !!line.find(part => part.startsWith('@unique')),
               list: line[1].includes('[]'),
               required: !line[1].includes('[]') && !line[1].includes('?'),
               kind: this.getKind(type),


### PR DESCRIPTION
The @id and @unique attributes now support arguments. This PR handles the case where @id and / or @unique have an argument list.