### PR TITLE
Enable building on Windows

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -20,7 +20,7 @@
     "build:es": "node ./scripts/build es",
     "build:copy-files": "node ./scripts/copyFiles",
     "build:types": "tsc -p tsconfig.build.json",
-    "build:css": "NODE_ENV=production tailwindcss-cli build -o ./dist/style.css"
+    "build:css": "cross-env NODE_ENV=production tailwindcss-cli build -o ./dist/style.css"
   },
   "dependencies": {
     "@headlessui/react": "^1.5.0",
@@ -48,6 +48,7 @@
     "@types/react-table": "7.7.9",
     "autoprefixer": "^10.4.2",
     "babel-plugin-module-resolver": "^4.1.0",
+    "cross-env": "^7.0.3",
     "fs-extra": "^10.0.1",
     "glob": "^7.2.0",
     "graphql-tag": "2.12.6",

--- a/packages/admin/scripts/build.js
+++ b/packages/admin/scripts/build.js
@@ -39,7 +39,7 @@ async function run(argv) {
   );
 
   const command = [
-    'yarn babel',
+    'pnpm babel',
     '--config-file',
     babelConfigPath,
     '--extensions',

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -14,9 +14,9 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "pnpm run clean && tsc -p tsconfig.build.json && yarn build:examples",
+    "build": "pnpm run clean && tsc -p tsconfig.build.json && pnpm run build:examples",
     "build:examples": "wait-on dist/index.js && node updatePalversion.js && rimraf examples/**/node_modules && cpy --dot --parents '!/node_modules/' examples dist",
-    "clean": "rm -rf dist node_modules/.cache"
+    "clean": "rimraf dist node_modules/.cache"
   },
   "dependencies": {
     "@paljs/display": "workspace:*",

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist node_modules/.cache"
+    "clean": "rimraf dist node_modules/.cache"
   },
   "author": {
     "name": "Ahmed Elywa",
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/node": "18.15.3",
+    "rimraf": "^3.0.2",
     "typescript": "^5.1.6"
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "scripts": {
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist node_modules/.cache"
+    "clean": "rimraf dist node_modules/.cache"
   },
   "dependencies": {
     "@paljs/types": "workspace:*",
@@ -28,6 +28,7 @@
     "@types/node": "18.15.3",
     "@types/pluralize": "^0.0.29",
     "@types/prettier": "^2.7.2",
+    "rimraf": "^3.0.2",
     "typescript": "^5.1.6"
   },
   "files": [

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "scripts": {
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist node_modules/.cache"
+    "clean": "rimraf dist node_modules/.cache"
   },
   "peerDependencies": {
     "@prisma/client": "^4",
@@ -37,6 +37,7 @@
     "@types/lowdb": "1.0.11",
     "graphql": "^16.6.0",
     "nexus": "^1.3.0",
+    "rimraf": "^3.0.2",
     "typescript": "^5.1.6"
   },
   "files": [

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "scripts": {
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist node_modules/.cache"
+    "clean": "rimraf dist node_modules/.cache"
   },
   "peerDependencies": {
     "@prisma/client": "^4",
@@ -36,6 +36,7 @@
     "@types/prettier": "^2.7.2",
     "@apollo/server": "^4.5.0",
     "graphql": "^16.6.0",
+    "rimraf": "^3.0.2",
     "typescript": "^5.1.6"
   },
   "files": [

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "scripts": {
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist node_modules/.cache"
+    "clean": "rimraf dist node_modules/.cache"
   },
   "publishConfig": {
     "access": "public"
@@ -25,6 +25,7 @@
     "@paljs/utils": "workspace:*"
   },
   "devDependencies": {
+    "rimraf": "^3.0.2",
     "typescript": "^5.1.6"
   },
   "files": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,13 +14,14 @@
   "private": false,
   "scripts": {
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist node_modules/.cache"
+    "clean": "rimraf dist node_modules/.cache"
   },
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
     "@prisma/generator-helper": "^5.1.1",
+    "rimraf": "^3.0.2",
     "typescript": "^5.1.6"
   },
   "files": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,12 +14,13 @@
   "private": false,
   "scripts": {
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist node_modules/.cache"
+    "clean": "rimraf dist node_modules/.cache"
   },
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
+    "rimraf": "^3.0.2",
     "typescript": "^5.1.6"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       babel-plugin-module-resolver:
         specifier: ^4.1.0
         version: 4.1.0
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       fs-extra:
         specifier: ^10.0.1
         version: 10.1.0
@@ -334,6 +337,9 @@ importers:
       '@types/node':
         specifier: 18.15.3
         version: 18.15.3
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -368,6 +374,9 @@ importers:
       '@types/prettier':
         specifier: ^2.7.2
         version: 2.7.2
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -408,6 +417,9 @@ importers:
       nexus:
         specifier: ^1.3.0
         version: 1.3.0(graphql@16.6.0)
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -448,6 +460,9 @@ importers:
       graphql:
         specifier: ^16.6.0
         version: 16.6.0
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -464,6 +479,9 @@ importers:
         specifier: workspace:*
         version: link:../utils
     devDependencies:
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -473,6 +491,9 @@ importers:
       '@prisma/generator-helper':
         specifier: ^5.1.1
         version: 5.1.1
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -489,6 +510,9 @@ importers:
         specifier: ^5.1.1
         version: 5.1.1
     devDependencies:
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -5478,7 +5502,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /concurrently@7.5.0:
     resolution: {integrity: sha512-5E3mwiS+i2JYBzr5BpXkFxOnleZTMsG+WnE/dCG4/P+oiVXrbmrBwJ2ozn4SxwB2EZDrKR568X+puVohxz3/Mg==}
@@ -5638,6 +5662,14 @@ packages:
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
+  /cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
     dev: true
 
   /cross-spawn@5.1.0:
@@ -7665,6 +7697,7 @@ packages:
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
     dev: true


### PR DESCRIPTION
This PR removes the dependency on Yarn and standardises on using pnpm. It also uses cross platform tools to enable building on Windows.