### PR TITLE
Make findMany return a non-nullable array

### DIFF
--- a/packages/generator/src/graphql-modules/CreateQueriesAndMutations.ts
+++ b/packages/generator/src/graphql-modules/CreateQueriesAndMutations.ts
@@ -42,7 +42,7 @@ export async function createQueriesAndMutations(
 
   if (!exclude.includes('findMany')) {
     operations.queries.type += `
-    findMany${name}(${await args('findMany')}): [${modelName}!]`;
+    findMany${name}(${await args('findMany')}): [${modelName}!]!`;
     operations.queries.resolver += `
     findMany${name}: (_parent, args, { injector }: GraphQLModules.Context) => {
       return injector.get(PrismaProvider).${model}.findMany(args);

--- a/packages/generator/src/sdl/CreateQueriesAndMutations.ts
+++ b/packages/generator/src/sdl/CreateQueriesAndMutations.ts
@@ -41,7 +41,7 @@ export async function createQueriesAndMutations(
 
   if (!exclude.includes('findMany')) {
     operations.queries.type += `
-    findMany${name}(${await args('findMany')}): [${modelName}!]`;
+    findMany${name}(${await args('findMany')}): [${modelName}!]!`;
     operations.queries.resolver += `
     findMany${name}: (_parent, args, {${prismaName}}) => {
       return ${prismaName}.${model}.findMany(args)

--- a/packages/generator/tests/SDL/__snapshots__/generateSDLModels.test.ts.snap
+++ b/packages/generator/tests/SDL/__snapshots__/generateSDLModels.test.ts.snap
@@ -74,7 +74,7 @@ export default gql\`
       take: Int
       skip: Int
       distinct: [UserScalarFieldEnum]
-    ): [User!]
+    ): [User!]!
     aggregateUser(
       where: UserWhereInput
       orderBy: [UserOrderByWithRelationInput]
@@ -176,7 +176,7 @@ export default gql\`
       take: Int
       skip: Int
       distinct: [PostScalarFieldEnum]
-    ): [Post!]
+    ): [Post!]!
     findManyPostCount(
       where: PostWhereInput
       orderBy: [PostOrderByWithRelationInput]
@@ -294,7 +294,7 @@ export default gql\`
       take: Int
       skip: Int
       distinct: [UserScalarFieldEnum]
-    ): [User!]
+    ): [User!]!
     findManyUserCount(
       where: UserWhereInput
       orderBy: [UserOrderByWithRelationInput]

--- a/packages/generator/tests/graphql-modules/__snapshots__/generateModulesModels.test.ts.snap
+++ b/packages/generator/tests/graphql-modules/__snapshots__/generateModulesModels.test.ts.snap
@@ -101,7 +101,7 @@ export default gql\`
       take: Int
       skip: Int
       distinct: [PostScalarFieldEnum]
-    ): [Post!]
+    ): [Post!]!
     aggregatePost(
       where: PostWhereInput
       orderBy: [PostOrderByWithRelationInput]
@@ -217,7 +217,7 @@ export default gql\`
       take: Int
       skip: Int
       distinct: [UserScalarFieldEnum]
-    ): [User!]
+    ): [User!]!
     aggregateUser(
       where: UserWhereInput
       orderBy: [UserOrderByWithRelationInput]
@@ -354,7 +354,7 @@ export default gql\`
       take: Int
       skip: Int
       distinct: [PostScalarFieldEnum]
-    ): [Post!]
+    ): [Post!]!
     findManyPostCount(
       where: PostWhereInput
       orderBy: [PostOrderByWithRelationInput]
@@ -493,7 +493,7 @@ export default gql\`
       take: Int
       skip: Int
       distinct: [UserScalarFieldEnum]
-    ): [User!]
+    ): [User!]!
     findManyUserCount(
       where: UserWhereInput
       orderBy: [UserOrderByWithRelationInput]


### PR DESCRIPTION
Prisma's findMany doesn't return an optional array, so the generated GraphQL type shouldn't be nullable.