### PR TITLE
Add more generic line separator in getting models and enums regexp

### DIFF
--- a/packages/schema/src/PrismaReader.ts
+++ b/packages/schema/src/PrismaReader.ts
@@ -11,11 +11,11 @@ export class PrismaReader {
   }
 
   get models() {
-    return this.data.match(/\n(model(\s)[\s\S]*?})\n/g);
+    return this.data.match(/\n(model(\s)[\s\S]*?})\r?\n/g);
   }
 
   get enums() {
-    return this.data.match(/\n(enum(\s)[\s\S]*?})\n/g);
+    return this.data.match(/\n(enum(\s)[\s\S]*?})\r?\n/g);
   }
 
   getModelDocumentation(modelName: string) {


### PR DESCRIPTION
So I was using paljs for quite a long time, but one day for some reason it just generated empty `adminSettings.json` and I struggled a lot debugging and finding out what was the problem, and the problem was this. It failed to read schema because of the different line separators. 
So, I am doing this pull-request just so the regexp would be more universal and nobody else have to deal with such non-obvious hard-to-findable issue.
P.S. Thank you for the library.