### PR TITLE
Don't check error message due to platform path separator differences

### DIFF
--- a/packages/utils/tests/__snapshots__/dmmf.test.ts.snap
+++ b/packages/utils/tests/__snapshots__/dmmf.test.ts.snap
@@ -15712,15 +15712,3 @@ exports[`test read schema and convert to dmmf build DMMF from schema 1`] = `
   },
 }
 `;
-
-exports[`test read schema and convert to dmmf failing load schema path 1`] = `
-"Could not find Prisma Schema that is required for this command.
-You can either provide it with \`--schema\` argument, set it as \`prisma.schema\` in your package.json or put it into the default location.
-Checked following paths:
-
-schema.prisma: file not found
-prisma/schema.prisma: file not found
-prisma/schema: directory not found
-
-See also https://pris.ly/d/prisma-schema-location"
-`;

--- a/packages/utils/tests/dmmf.test.ts
+++ b/packages/utils/tests/dmmf.test.ts
@@ -4,7 +4,7 @@ import { getDMMFBySchemaPath, getSchemaPath } from 'dmmf';
 describe('test read schema and convert to dmmf', () => {
   const schemaPath = join(__dirname, './schemas/schema.prisma');
   test('failing load schema path', async () => {
-    await expect(getSchemaPath()).rejects.toThrowErrorMatchingSnapshot();
+    await expect(getSchemaPath()).rejects.toThrow();
   });
 
   test('success load schema path', async () => {


### PR DESCRIPTION
The lines with path separators come from Prisma, so I don't think there's an easy way to handle this. This PR just changes the expectation to throw, instead of throwing with a specific message.