### PR TITLE
fix: large response array size call 'require()' many times make gql slow

### DIFF
--- a/packages/plugins/src/select.ts
+++ b/packages/plugins/src/select.ts
@@ -1,6 +1,7 @@
 import { GraphQLResolveInfo } from 'graphql';
 import { DMMF } from '@paljs/types';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
+import { Prisma } from '@prisma/client';
 
 export interface PrismaSelectOptions<
   ModelName extends string,
@@ -122,8 +123,9 @@ export class PrismaSelect<
       });
       return models;
     } else {
-      const { Prisma } = require('@prisma/client');
+      // @ts-ignore: Prisma.dmmf is a lazy/runtime property and not defined in @prisma/client ts type
       if (Prisma.dmmf && Prisma.dmmf.datamodel) {
+        // @ts-ignore
         return Prisma.dmmf.datamodel.models;
       } else {
         return [];

--- a/packages/plugins/src/select.ts
+++ b/packages/plugins/src/select.ts
@@ -123,10 +123,10 @@ export class PrismaSelect<
       });
       return models;
     } else {
-      // @ts-ignore: Prisma.dmmf is a lazy/runtime property and not defined in @prisma/client ts type
-      if (Prisma.dmmf && Prisma.dmmf.datamodel) {
-        // @ts-ignore
-        return Prisma.dmmf.datamodel.models;
+      // Prisma.dmmf is a lazy/runtime property and not defined in @prisma/client ts type
+      const dmmf = (Prisma as any).dmmf;
+      if (dmmf && dmmf.datamodel) {
+        return dmmf.datamodel.models;
       } else {
         return [];
       }


### PR DESCRIPTION
my response data is about 4000 of a array, and move 'require()' to the top of file will faster
![Screenshot 2024-09-19 114807](https://github.com/user-attachments/assets/7707f4f2-e34b-4ab3-a6f8-4e6cb0e91cad)

change before it take 5.6s, after it take 0.2s
![image](https://github.com/user-attachments/assets/72aed00d-b236-4b71-bd9d-2af246d6f5ee)
