### PR TITLE
Fix UpdateManyAndReturn type

### DIFF
--- a/packages/generator/src/sdl/GenerateTypes.ts
+++ b/packages/generator/src/sdl/GenerateTypes.ts
@@ -57,6 +57,10 @@ export class GenerateTypes {
       const innerType = name.replace(/^CreateMany|AndReturnOutputType$/g, '');
       return `ReturnType<Client.Prisma.${innerType}Delegate["createManyAndReturn"]>`;
     }
+    if (name.startsWith('UpdateMany') && name.endsWith('AndReturnOutputType')) {
+      const innerType = name.replace(/^UpdateMany|AndReturnOutputType$/g, '');
+      return `ReturnType<Client.Prisma.${innerType}Delegate["updateManyAndReturn"]>`;
+    }
     return `Client.Prisma.${name}`;
   }
 
@@ -77,6 +81,10 @@ export class GenerateTypes {
         if (options.type.startsWith('CreateMany') && options.type.endsWith('AndReturnOutputType')) {
           const innerType = options.type.replace(/^CreateMany|AndReturnOutputType$/g, '');
           return `ReturnType<Client.Prisma.${innerType}Delegate["createManyAndReturn"]>`;
+        }
+        if (options.type.startsWith('UpdateMany') && options.type.endsWith('AndReturnOutputType')) {
+          const innerType = options.type.replace(/^UpdateMany|AndReturnOutputType$/g, '');
+          return `ReturnType<Client.Prisma.${innerType}Delegate["updateManyAndReturn"]>`;
         }
         const type =
           options.type.toString() === 'AffectedRowsOutput'

--- a/packages/generator/tests/SDL/__snapshots__/generateSDLTypescript.test.ts.snap
+++ b/packages/generator/tests/SDL/__snapshots__/generateSDLTypescript.test.ts.snap
@@ -114,25 +114,33 @@ export type CreateManyUserAndReturnOutputType = {
 export type UpdateManyUserAndReturnOutputType = {
   [key: string]: Resolver<any, any, any>
 } & {
-  id?: Resolver<Client.Prisma.UpdateManyUserAndReturnOutputType, {}, number>
+  id?: Resolver<
+    ReturnType<Client.Prisma.UserDelegate['updateManyAndReturn']>,
+    {},
+    number
+  >
   createdAt?: Resolver<
-    Client.Prisma.UpdateManyUserAndReturnOutputType,
+    ReturnType<Client.Prisma.UserDelegate['updateManyAndReturn']>,
     {},
     Date
   >
-  email?: Resolver<Client.Prisma.UpdateManyUserAndReturnOutputType, {}, string>
+  email?: Resolver<
+    ReturnType<Client.Prisma.UserDelegate['updateManyAndReturn']>,
+    {},
+    string
+  >
   name?: Resolver<
-    Client.Prisma.UpdateManyUserAndReturnOutputType,
+    ReturnType<Client.Prisma.UserDelegate['updateManyAndReturn']>,
     {},
     string | null
   >
   password?: Resolver<
-    Client.Prisma.UpdateManyUserAndReturnOutputType,
+    ReturnType<Client.Prisma.UserDelegate['updateManyAndReturn']>,
     {},
     string
   >
   permissions?: Resolver<
-    Client.Prisma.UpdateManyUserAndReturnOutputType,
+    ReturnType<Client.Prisma.UserDelegate['updateManyAndReturn']>,
     {},
     any
   >
@@ -181,30 +189,38 @@ export type CreateManyPostAndReturnOutputType = {
 export type UpdateManyPostAndReturnOutputType = {
   [key: string]: Resolver<any, any, any>
 } & {
-  id?: Resolver<Client.Prisma.UpdateManyPostAndReturnOutputType, {}, number>
+  id?: Resolver<
+    ReturnType<Client.Prisma.PostDelegate['updateManyAndReturn']>,
+    {},
+    number
+  >
   published?: Resolver<
-    Client.Prisma.UpdateManyPostAndReturnOutputType,
+    ReturnType<Client.Prisma.PostDelegate['updateManyAndReturn']>,
     {},
     boolean
   >
-  title?: Resolver<Client.Prisma.UpdateManyPostAndReturnOutputType, {}, string>
+  title?: Resolver<
+    ReturnType<Client.Prisma.PostDelegate['updateManyAndReturn']>,
+    {},
+    string
+  >
   authorId?: Resolver<
-    Client.Prisma.UpdateManyPostAndReturnOutputType,
+    ReturnType<Client.Prisma.PostDelegate['updateManyAndReturn']>,
     {},
     number | null
   >
   createdAt?: Resolver<
-    Client.Prisma.UpdateManyPostAndReturnOutputType,
+    ReturnType<Client.Prisma.PostDelegate['updateManyAndReturn']>,
     {},
     Date
   >
   updatedAt?: Resolver<
-    Client.Prisma.UpdateManyPostAndReturnOutputType,
+    ReturnType<Client.Prisma.PostDelegate['updateManyAndReturn']>,
     {},
     Date
   >
   author?: Resolver<
-    Client.Prisma.UpdateManyPostAndReturnOutputType,
+    ReturnType<Client.Prisma.PostDelegate['updateManyAndReturn']>,
     UpdateManyPostAndReturnOutputTypeAuthorArgs,
     Client.User | null
   >
@@ -276,7 +292,7 @@ export type Mutation = { [key: string]: Resolver<any, any, any> } & {
   updateManyUserAndReturn?: Resolver<
     {},
     UpdateManyUserAndReturnArgs,
-    Client.Prisma.UpdateManyUserAndReturnOutputType[]
+    ReturnType<Client.Prisma.UserDelegate['updateManyAndReturn']>
   >
   deleteManyUser?: Resolver<{}, DeleteManyUserArgs, Client.Prisma.BatchPayload>
   createOnePost?: Resolver<{}, CreateOnePostArgs, Client.Post>
@@ -293,7 +309,7 @@ export type Mutation = { [key: string]: Resolver<any, any, any> } & {
   updateManyPostAndReturn?: Resolver<
     {},
     UpdateManyPostAndReturnArgs,
-    Client.Prisma.UpdateManyPostAndReturnOutputType[]
+    ReturnType<Client.Prisma.PostDelegate['updateManyAndReturn']>
   >
   deleteManyPost?: Resolver<{}, DeleteManyPostArgs, Client.Prisma.BatchPayload>
   executeRaw?: Resolver<{}, ExecuteRawArgs, any>


### PR DESCRIPTION
Hi @AhmedElywa,

There is a problem with the new UpdateManyAndReturn feature Prisma introduced as of Prisma v6.2.0.  Similar to issue https://github.com/AhmedElywa/prisma-tools/issues/335, `@paljs/generator` is not producing the correct types for the file `resolversTypes.ts`.

It is generating `Client.Prisma.UpdateManyUserAndReturnOutputType` which does not exist.  Instead of `ReturnType<Client.Prisma.UserDelegate['updateManyAndReturn']>` which does.

This pull request remedies the issue.  Cheers 🥂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type generation to support UpdateMany…AndReturn outputs, providing accurate return types for updateManyAndReturn operations.
  * Aligns behavior with existing CreateMany…AndReturn support for a consistent developer experience.
  * Enhances TypeScript autocomplete and type safety when working with update-many-and-return flows.
* **Chores**
  * Internal type-generation logic extended without changing public APIs or altering existing code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->