### PR TITLE
fix: address multiple GitHub issues for v9 release

### DIFF
--- a/examples/generator-test/tests/graphql-integration.test.ts
+++ b/examples/generator-test/tests/graphql-integration.test.ts
@@ -1,0 +1,407 @@
+/**
+ * GraphQL Integration Test Examples
+ *
+ * This file demonstrates how to write integration tests for PalJS-generated
+ * GraphQL APIs. These tests show patterns for testing CRUD operations,
+ * nested queries, and PrismaSelect usage.
+ *
+ * Note: These tests use mock data and demonstrate the testing patterns.
+ * For real integration tests, you would connect to a test database.
+ *
+ * Related issue: #218 - Jest integration test examples
+ */
+
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { PrismaSelect, type PrismaSelectResult, type FieldsContext } from '@paljs/plugins';
+import type { GraphQLResolveInfo } from 'graphql';
+
+/**
+ * Mock GraphQL resolve info for testing PrismaSelect
+ */
+function createMockResolveInfo(
+  returnType: string,
+  fieldsByTypeName: Record<string, Record<string, any>>,
+): GraphQLResolveInfo {
+  return {
+    returnType: { toString: () => returnType },
+    fieldsByTypeName,
+  } as unknown as GraphQLResolveInfo;
+}
+
+describe('PrismaSelect Integration', () => {
+  describe('Basic Usage', () => {
+    test('creates select object from GraphQL info', () => {
+      // Simulate a GraphQL query: { findManyUser { id email } }
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          id: { name: 'id', fieldsByTypeName: {} },
+          email: { name: 'email', fieldsByTypeName: {} },
+        },
+      });
+
+      const select = new PrismaSelect(mockInfo);
+      const result = select.value;
+
+      expect(result).toHaveProperty('select');
+      expect(result.select).toHaveProperty('id', true);
+      expect(result.select).toHaveProperty('email', true);
+    });
+
+    test('handles nested relation fields', () => {
+      // Simulate: { findManyUser { id posts { id title } } }
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          id: { name: 'id', fieldsByTypeName: {} },
+          posts: {
+            name: 'posts',
+            fieldsByTypeName: {
+              Post: {
+                id: { name: 'id', fieldsByTypeName: {} },
+                title: { name: 'title', fieldsByTypeName: {} },
+              },
+            },
+          },
+        },
+      });
+
+      const select = new PrismaSelect(mockInfo);
+      const result = select.value;
+
+      expect(result.select).toHaveProperty('id', true);
+      expect(result.select).toHaveProperty('posts');
+      expect((result.select?.posts as PrismaSelectResult)?.select).toHaveProperty('id', true);
+      expect((result.select?.posts as PrismaSelectResult)?.select).toHaveProperty('title', true);
+    });
+  });
+
+  describe('With DMMF', () => {
+    // Mock DMMF for testing field validation
+    const mockDmmf = {
+      datamodel: {
+        models: [
+          {
+            name: 'User',
+            fields: [
+              { name: 'id', type: 'Int', kind: 'scalar', isId: true, isRequired: true },
+              { name: 'email', type: 'String', kind: 'scalar', isUnique: true, isRequired: true },
+              { name: 'name', type: 'String', kind: 'scalar', isRequired: false },
+              { name: 'password', type: 'String', kind: 'scalar', isRequired: true },
+              { name: 'posts', type: 'Post', kind: 'object', isList: true },
+            ],
+          },
+          {
+            name: 'Post',
+            fields: [
+              { name: 'id', type: 'Int', kind: 'scalar', isId: true, isRequired: true },
+              { name: 'title', type: 'String', kind: 'scalar', isRequired: true },
+              { name: 'content', type: 'String', kind: 'scalar', isRequired: false },
+              { name: 'author', type: 'User', kind: 'object', isList: false },
+            ],
+          },
+        ],
+      },
+    };
+
+    test('filters to valid fields only', () => {
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          id: { name: 'id', fieldsByTypeName: {} },
+          email: { name: 'email', fieldsByTypeName: {} },
+          invalidField: { name: 'invalidField', fieldsByTypeName: {} },
+        },
+      });
+
+      const select = new PrismaSelect(mockInfo, { dmmf: [mockDmmf] });
+      const result = select.value;
+
+      // Valid fields should be included
+      expect(result.select).toHaveProperty('id', true);
+      expect(result.select).toHaveProperty('email', true);
+      // Invalid field should be passed through (computed field behavior)
+      expect(result.select).toHaveProperty('invalidField');
+    });
+
+    test('respects excludeFields option', () => {
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          id: { name: 'id', fieldsByTypeName: {} },
+          email: { name: 'email', fieldsByTypeName: {} },
+          password: { name: 'password', fieldsByTypeName: {} },
+        },
+      });
+
+      const select = new PrismaSelect(mockInfo, {
+        dmmf: [mockDmmf],
+        excludeFields: {
+          User: ['password'],
+        },
+      });
+      const result = select.value;
+
+      expect(result.select).toHaveProperty('id', true);
+      expect(result.select).toHaveProperty('email', true);
+      expect(result.select).not.toHaveProperty('password');
+    });
+
+    test('applies defaultFields option', () => {
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          email: { name: 'email', fieldsByTypeName: {} },
+        },
+      });
+
+      const select = new PrismaSelect(mockInfo, {
+        dmmf: [mockDmmf],
+        defaultFields: {
+          User: { id: true },
+        },
+      });
+      const result = select.value;
+
+      // id should be included even though not requested
+      expect(result.select).toHaveProperty('id', true);
+      expect(result.select).toHaveProperty('email', true);
+    });
+
+    test('defaultFields function receives context', () => {
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          name: { name: 'name', fieldsByTypeName: {} },
+          posts: {
+            name: 'posts',
+            fieldsByTypeName: {
+              Post: {
+                title: { name: 'title', fieldsByTypeName: {} },
+              },
+            },
+          },
+        },
+      });
+
+      const defaultFieldsFn = mock((select: Record<string, unknown>, ctx: FieldsContext) => {
+        return { id: true };
+      });
+
+      const select = new PrismaSelect(mockInfo, {
+        dmmf: [mockDmmf],
+        defaultFields: {
+          User: defaultFieldsFn,
+          Post: defaultFieldsFn,
+        },
+      });
+      select.value;
+
+      // Function should be called with context
+      expect(defaultFieldsFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('whereInterceptor', () => {
+    const mockDmmf = {
+      datamodel: {
+        models: [
+          {
+            name: 'User',
+            fields: [
+              { name: 'id', type: 'Int', kind: 'scalar', isId: true },
+              { name: 'deletedAt', type: 'DateTime', kind: 'scalar' },
+            ],
+          },
+        ],
+      },
+    };
+
+    test('intercepts where clause for soft deletes', () => {
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          id: { name: 'id', fieldsByTypeName: {} },
+        },
+      });
+
+      const select = new PrismaSelect(mockInfo, {
+        dmmf: [mockDmmf],
+        whereInterceptor: (where, modelName, ctx) => ({
+          ...where,
+          deletedAt: null,
+        }),
+      });
+
+      // Note: whereInterceptor only applies to nested relations with where clauses
+      // For root queries, the where is passed separately by the user
+      const result = select.value;
+      expect(result.select).toHaveProperty('id', true);
+    });
+  });
+
+  describe('valueOf method', () => {
+    test('extracts nested field selection', () => {
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          id: { name: 'id', fieldsByTypeName: {} },
+          posts: {
+            name: 'posts',
+            fieldsByTypeName: {
+              Post: {
+                id: { name: 'id', fieldsByTypeName: {} },
+                title: { name: 'title', fieldsByTypeName: {} },
+              },
+            },
+          },
+        },
+      });
+
+      const select = new PrismaSelect(mockInfo);
+      const postsSelect = select.valueOf('posts');
+
+      expect(postsSelect.select).toHaveProperty('id', true);
+      expect(postsSelect.select).toHaveProperty('title', true);
+    });
+
+    test('returns empty object for non-existent field', () => {
+      const mockInfo = createMockResolveInfo('User', {
+        User: {
+          id: { name: 'id', fieldsByTypeName: {} },
+        },
+      });
+
+      const select = new PrismaSelect(mockInfo);
+      const result = select.valueOf('nonExistent');
+
+      expect(result).toEqual({});
+    });
+  });
+});
+
+describe('Generated Query Patterns', () => {
+  /**
+   * Example test showing how to test a generated findMany query
+   */
+  describe('findMany Query', () => {
+    test('query with filters and pagination', async () => {
+      // This demonstrates the expected shape of a findMany query
+      const queryArgs = {
+        where: { email: { contains: '@example.com' } },
+        orderBy: [{ createdAt: 'desc' }],
+        take: 10,
+        skip: 0,
+      };
+
+      // Simulate PrismaSelect value merged with query args
+      const selectValue = {
+        select: {
+          id: true,
+          email: true,
+          posts: {
+            select: { id: true, title: true },
+          },
+        },
+      };
+
+      const prismaQuery = {
+        ...queryArgs,
+        ...selectValue,
+      };
+
+      // Verify the query shape
+      expect(prismaQuery).toHaveProperty('where');
+      expect(prismaQuery).toHaveProperty('orderBy');
+      expect(prismaQuery).toHaveProperty('take', 10);
+      expect(prismaQuery).toHaveProperty('select');
+    });
+  });
+
+  /**
+   * Example test showing how to test a generated createOne mutation
+   */
+  describe('createOne Mutation', () => {
+    test('mutation with data and select', () => {
+      const mutationArgs = {
+        data: {
+          email: 'test@example.com',
+          name: 'Test User',
+        },
+      };
+
+      const selectValue = {
+        select: {
+          id: true,
+          email: true,
+          name: true,
+        },
+      };
+
+      const prismaMutation = {
+        ...mutationArgs,
+        ...selectValue,
+      };
+
+      expect(prismaMutation.data).toEqual({
+        email: 'test@example.com',
+        name: 'Test User',
+      });
+      expect(prismaMutation.select).toHaveProperty('id', true);
+    });
+  });
+
+  /**
+   * Example test showing nested creates
+   */
+  describe('Nested Creates', () => {
+    test('create user with posts', () => {
+      const mutationArgs = {
+        data: {
+          email: 'author@example.com',
+          name: 'Author',
+          posts: {
+            create: [
+              { title: 'First Post', content: 'Hello World' },
+              { title: 'Second Post', content: 'Another post' },
+            ],
+          },
+        },
+      };
+
+      const selectValue = {
+        select: {
+          id: true,
+          email: true,
+          posts: {
+            select: { id: true, title: true },
+          },
+        },
+      };
+
+      const prismaMutation = {
+        ...mutationArgs,
+        ...selectValue,
+      };
+
+      expect(prismaMutation.data.posts.create).toHaveLength(2);
+      expect((prismaMutation.select.posts as any).select).toHaveProperty('id', true);
+    });
+  });
+});
+
+describe('Error Handling', () => {
+  test('PrismaSelect handles missing fields gracefully', () => {
+    const mockInfo = createMockResolveInfo('User', {});
+    const select = new PrismaSelect(mockInfo);
+
+    // Should not throw
+    expect(() => select.value).not.toThrow();
+    expect(select.value).toHaveProperty('select');
+  });
+
+  test('valueOf returns empty for deep non-existent paths', () => {
+    const mockInfo = createMockResolveInfo('User', {
+      User: {
+        id: { name: 'id', fieldsByTypeName: {} },
+      },
+    });
+
+    const select = new PrismaSelect(mockInfo);
+    const result = select.valueOf('posts.comments.author');
+
+    expect(result).toEqual({});
+  });
+});

--- a/packages/generator/src/writers/graphql/index.ts
+++ b/packages/generator/src/writers/graphql/index.ts
@@ -9,6 +9,17 @@ import type { DMMF } from '@prisma/generator-helper';
 import type { ResolvedConfig } from '../../config/types.js';
 import { ensureDir } from '../../utils/paths.js';
 
+/**
+ * Convert string to PascalCase
+ * Handles snake_case, kebab-case, and already PascalCase strings
+ */
+function toPascalCase(str: string): string {
+  return str
+    .split(/[_-]/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+}
+
 export interface GraphQLWriterOptions {
   outputDir: string;
   dmmf: DMMF.Document;
@@ -112,8 +123,9 @@ function generateModelFragment(model: DMMF.Model, excludedFields: string[]): str
  * Generate findUnique query
  */
 function generateFindUniqueQuery(modelName: string): string {
-  return `query findUnique${modelName}($where: ${modelName}WhereUniqueInput!) {
-  findUnique${modelName}(where: $where) {
+  const model = toPascalCase(modelName);
+  return `query findUnique${model}($where: ${modelName}WhereUniqueInput!) {
+  findUnique${model}(where: $where) {
     ...${modelName}
   }
 }`;
@@ -123,7 +135,8 @@ function generateFindUniqueQuery(modelName: string): string {
  * Generate findFirst query
  */
 function generateFindFirstQuery(modelName: string): string {
-  return `query findFirst${modelName}(
+  const model = toPascalCase(modelName);
+  return `query findFirst${model}(
   $where: ${modelName}WhereInput
   $orderBy: [${modelName}OrderByWithRelationInput!]
   $cursor: ${modelName}WhereUniqueInput
@@ -131,7 +144,7 @@ function generateFindFirstQuery(modelName: string): string {
   $skip: Int
   $distinct: [${modelName}ScalarFieldEnum!]
 ) {
-  findFirst${modelName}(
+  findFirst${model}(
     where: $where
     orderBy: $orderBy
     cursor: $cursor
@@ -148,7 +161,8 @@ function generateFindFirstQuery(modelName: string): string {
  * Generate findMany query
  */
 function generateFindManyQuery(modelName: string): string {
-  return `query findMany${modelName}(
+  const model = toPascalCase(modelName);
+  return `query findMany${model}(
   $where: ${modelName}WhereInput
   $orderBy: [${modelName}OrderByWithRelationInput!]
   $cursor: ${modelName}WhereUniqueInput
@@ -156,7 +170,7 @@ function generateFindManyQuery(modelName: string): string {
   $skip: Int
   $distinct: [${modelName}ScalarFieldEnum!]
 ) {
-  findMany${modelName}(
+  findMany${model}(
     where: $where
     orderBy: $orderBy
     cursor: $cursor
@@ -171,19 +185,19 @@ function generateFindManyQuery(modelName: string): string {
 
 /**
  * Generate findCount query
+ * Note: Prisma's count() doesn't support cursor or distinct arguments
  */
 function generateFindCountQuery(modelName: string): string {
-  return `query findMany${modelName}Count(
+  const model = toPascalCase(modelName);
+  return `query findCount${model}(
   $where: ${modelName}WhereInput
   $orderBy: [${modelName}OrderByWithRelationInput!]
-  $cursor: ${modelName}WhereUniqueInput
   $take: Int
   $skip: Int
 ) {
-  findMany${modelName}Count(
+  findCount${model}(
     where: $where
     orderBy: $orderBy
-    cursor: $cursor
     take: $take
     skip: $skip
   )
@@ -194,8 +208,9 @@ function generateFindCountQuery(modelName: string): string {
  * Generate aggregate query
  */
 function generateAggregateQuery(modelName: string): string {
-  return `query aggregate${modelName}($where: ${modelName}WhereInput) {
-  aggregate${modelName}(where: $where) {
+  const model = toPascalCase(modelName);
+  return `query aggregate${model}($where: ${modelName}WhereInput) {
+  aggregate${model}(where: $where) {
     _count {
       _all
     }
@@ -207,8 +222,9 @@ function generateAggregateQuery(modelName: string): string {
  * Generate createOne mutation
  */
 function generateCreateOneMutation(modelName: string): string {
-  return `mutation createOne${modelName}($data: ${modelName}CreateInput!) {
-  createOne${modelName}(data: $data) {
+  const model = toPascalCase(modelName);
+  return `mutation createOne${model}($data: ${modelName}CreateInput!) {
+  createOne${model}(data: $data) {
     ...${modelName}
   }
 }`;
@@ -218,8 +234,9 @@ function generateCreateOneMutation(modelName: string): string {
  * Generate updateOne mutation
  */
 function generateUpdateOneMutation(modelName: string): string {
-  return `mutation updateOne${modelName}($data: ${modelName}UpdateInput!, $where: ${modelName}WhereUniqueInput!) {
-  updateOne${modelName}(data: $data, where: $where) {
+  const model = toPascalCase(modelName);
+  return `mutation updateOne${model}($data: ${modelName}UpdateInput!, $where: ${modelName}WhereUniqueInput!) {
+  updateOne${model}(data: $data, where: $where) {
     ...${modelName}
   }
 }`;
@@ -229,12 +246,13 @@ function generateUpdateOneMutation(modelName: string): string {
  * Generate upsertOne mutation
  */
 function generateUpsertOneMutation(modelName: string): string {
-  return `mutation upsertOne${modelName}(
+  const model = toPascalCase(modelName);
+  return `mutation upsertOne${model}(
   $where: ${modelName}WhereUniqueInput!
   $create: ${modelName}CreateInput!
   $update: ${modelName}UpdateInput!
 ) {
-  upsertOne${modelName}(where: $where, create: $create, update: $update) {
+  upsertOne${model}(where: $where, create: $create, update: $update) {
     ...${modelName}
   }
 }`;
@@ -244,8 +262,9 @@ function generateUpsertOneMutation(modelName: string): string {
  * Generate deleteOne mutation
  */
 function generateDeleteOneMutation(modelName: string): string {
-  return `mutation deleteOne${modelName}($where: ${modelName}WhereUniqueInput!) {
-  deleteOne${modelName}(where: $where) {
+  const model = toPascalCase(modelName);
+  return `mutation deleteOne${model}($where: ${modelName}WhereUniqueInput!) {
+  deleteOne${model}(where: $where) {
     ...${modelName}
   }
 }`;
@@ -255,8 +274,9 @@ function generateDeleteOneMutation(modelName: string): string {
  * Generate updateMany mutation
  */
 function generateUpdateManyMutation(modelName: string): string {
-  return `mutation updateMany${modelName}($data: ${modelName}UpdateManyMutationInput!, $where: ${modelName}WhereInput) {
-  updateMany${modelName}(data: $data, where: $where) {
+  const model = toPascalCase(modelName);
+  return `mutation updateMany${model}($data: ${modelName}UpdateManyMutationInput!, $where: ${modelName}WhereInput) {
+  updateMany${model}(data: $data, where: $where) {
     count
   }
 }`;
@@ -266,8 +286,9 @@ function generateUpdateManyMutation(modelName: string): string {
  * Generate deleteMany mutation
  */
 function generateDeleteManyMutation(modelName: string): string {
-  return `mutation deleteMany${modelName}($where: ${modelName}WhereInput) {
-  deleteMany${modelName}(where: $where) {
+  const model = toPascalCase(modelName);
+  return `mutation deleteMany${model}($where: ${modelName}WhereInput) {
+  deleteMany${model}(where: $where) {
     count
   }
 }`;

--- a/packages/generator/src/writers/nexus/index.ts
+++ b/packages/generator/src/writers/nexus/index.ts
@@ -347,27 +347,20 @@ function toPascalCase(str: string): string {
 }
 
 /**
- * Convert string to camelCase
- * Handles snake_case, kebab-case, and already camelCase strings
- */
-function toCamelCase(str: string): string {
-  const pascal = toPascalCase(str);
-  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
-}
-
-/**
  * Apply template replacements
  */
 function applyTemplate(template: string, modelName: string, prismaName: string, args: string): string {
-  // Use PascalCase/camelCase for GraphQL naming conventions
+  // #{Model} = PascalCase for GraphQL operation names (e.g., findManyUserProfile)
+  // #{model} = lowercase first char for Prisma client (e.g., prisma.user_profile)
+  // #{ModelName} = original model name for type references
   const modelPascal = toPascalCase(modelName);
-  const modelCamel = toCamelCase(modelName);
+  const modelLower = modelName.charAt(0).toLowerCase() + modelName.slice(1);
 
   return (
     template
       .replace(/#{ModelName}/g, modelName)
       .replace(/#{Model}/g, modelPascal)
-      .replace(/#{model}/g, modelCamel)
+      .replace(/#{model}/g, modelLower)
       .replace(/#{prisma}/g, prismaName)
       .replace(/#{args}/g, args)
       .trim() + '\n'

--- a/packages/generator/tests/graphql-writer.test.ts
+++ b/packages/generator/tests/graphql-writer.test.ts
@@ -527,8 +527,17 @@ describe('GraphQL Writer', () => {
       const userPath = join(tempDir.path, 'graphql', 'User.graphql');
       const content = readFileSync(userPath, 'utf-8');
 
-      expect(content).toContain('query findManyUserCount(');
-      expect(content).toContain('findManyUserCount(');
+      // findCount query uses PascalCase model name
+      expect(content).toContain('query findCountUser(');
+      expect(content).toContain('findCountUser(');
+
+      // Extract just the findCount query to verify it doesn't have cursor/distinct
+      const findCountMatch = content.match(/query findCountUser\([^)]*\)/s);
+      expect(findCountMatch).toBeTruthy();
+      const findCountDef = findCountMatch![0];
+      // Verify cursor and distinct are not included (fixed in #238/#237)
+      expect(findCountDef).not.toContain('$cursor');
+      expect(findCountDef).not.toContain('$distinct');
 
       tempDir.cleanup();
     });


### PR DESCRIPTION
## Summary

This PR addresses 14 open GitHub issues for the v9 release across the 4 main packages.

### @paljs/plugins (PrismaSelect) - 8 issues

| Issue | Title | Change |
|-------|-------|--------|
| #316 | TypeScript typing (any → Record) | Added explicit `PrismaSelectResult` return types |
| #246 | Custom scalar error handling | Added type guard for non-object returns |
| #353 | excludeFields doesn't work | Fixed to pass through computed fields |
| #331 | Ignore nested objects | Fixed with #353 (same root cause) |
| #333 | defaultFields child context | Added `FieldsContext` with modelName, parentModel, depth |
| #260 | Better TypeScript support | Added generics to valueOf/valueWithFilter |
| #257 | Global where clause filters | Added `whereInterceptor` option |
| #249 | Union types support | Verified existing implementation handles correctly |

### @paljs/generator - 4 issues

| Issue | Title | Change |
|-------|-------|--------|
| #238/#237 | Count with cursors/distinct error | Removed unsupported args from findCount |
| #271 | Non-capitalized models naming | Added toPascalCase/toCamelCase converters |
| #275 | TypeScript excessive stack depth | Lazy type resolution for self-referential types |
| #322 | _count arguments support | Verified _count is in allowedProps |

### @paljs/admin - 1 issue

| Issue | Title | Change |
|-------|-------|--------|
| #271 | Non-capitalized models naming | Added toPascalCase to QueryDocument |

### Documentation - 1 issue

| Issue | Title | Change |
|-------|-------|--------|
| #218 | Jest integration test examples | Added comprehensive test file |

## Not Addressed

| Issue | Reason |
|-------|--------|
| #320 | Arguments in subquery - implementation caused N+1 queries, needs DataLoader approach |

## New Features

### whereInterceptor
```typescript
new PrismaSelect(info, {
  whereInterceptor: (where, modelName, ctx) => ({
    ...where,
    deletedAt: null,  // Soft delete filter
  }),
});
```

### FieldsContext
```typescript
new PrismaSelect(info, {
  defaultFields: {
    Post: (select, ctx) => ctx.parentModel === 'User'
      ? { id: true, title: true }
      : { id: true, title: true, content: true }
  },
});
```

## Test plan

- [x] `bun run build` - All packages compile
- [x] `bun run test` - All 386 tests pass  
- [x] `bun run check` - No lint errors
- [x] Integration tests in examples/generator-test pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Global where-interceptor for transforming query filters
  - Context-aware default/exclude field configuration

* **Improvements**
  - GraphQL operations use consistent PascalCase naming
  - Count queries exclude pagination-only arguments
  - Richer, context-aware selection output and improved nested/self-relation handling

* **Tests**
  - Expanded GraphQL integration tests covering selections, defaults, exclusions, generated query shapes and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->