### PR TITLE
Add bugs metadata for PALJS packages

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -25,6 +25,9 @@
     "directory": "packages/admin"
   },
   "homepage": "https://paljs.com",
+  "bugs": {
+    "url": "https://github.com/AhmedElywa/prisma-tools/issues"
+  },
   "author": "Ahmed Elywa",
   "license": "MIT",
   "private": false,

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -52,6 +52,9 @@
     "directory": "packages/generator"
   },
   "homepage": "https://paljs.com",
+  "bugs": {
+    "url": "https://github.com/AhmedElywa/prisma-tools/issues"
+  },
   "author": "Ahmed Elywa",
   "license": "MIT",
   "publishConfig": {

--- a/packages/nexus/package.json
+++ b/packages/nexus/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/nexus"
   },
   "homepage": "https://paljs.com/",
+  "bugs": {
+    "url": "https://github.com/AhmedElywa/prisma-tools/issues"
+  },
   "author": "Ahmed Elywa",
   "license": "MIT",
   "private": false,

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/plugins"
   },
   "homepage": "https://paljs.com/",
+  "bugs": {
+    "url": "https://github.com/AhmedElywa/prisma-tools/issues"
+  },
   "author": "Ahmed Elywa",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary
- Add `bugs.url` metadata for `@paljs/generator`, `@paljs/admin`, `@paljs/nexus`, and `@paljs/plugins` so npm users can find the issue tracker from package metadata.
- Leave runtime code, dependencies, exports, package versions, and build output unchanged.

## Verification
- Node package metadata assertion for `packages/generator/package.json`, `packages/admin/package.json`, `packages/nexus/package.json`, and `packages/plugins/package.json`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `packages/generator`
- `npm pack --dry-run --ignore-scripts --json` from `packages/admin`
- `npm pack --dry-run --ignore-scripts --json` from `packages/nexus`
- `npm pack --dry-run --ignore-scripts --json` from `packages/plugins`

Note: the source checkout does not include built dist artifacts, so the dry-run pack verifies the source manifest/package path available in the checkout and does not rebuild release artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata across core packages to include a link to the project issues page for bug reporting and tracking. This adds a visible "Report a bug" reference in package metadata to streamline reporting from package consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->